### PR TITLE
Add dub configuration option

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,6 +39,8 @@ pub struct Config {
 
     /// Show titles in romaji (MAL's main title) instead of English.
     pub prefer_romaji: Option<bool>,
+
+    pub dub: Option<bool>,
 }
 
 impl Config {
@@ -66,6 +68,7 @@ impl Config {
             logging: Logging::default(),
             allow_nsfw: Some(true),
             prefer_romaji: Some(false),
+            dub: Some(false),
         }
     }
 

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -154,9 +154,15 @@ impl AnimePlayer {
         }
         let new_path = format!("{}:{}", shim_dir.display(), std::env::var("PATH").unwrap_or_default());
 
+        let mut dub = String::new();
+        if Config::global().dub.unwrap_or(false) {
+            dub.push_str("--dub");
+        }
+
         let mut child = Command::new("ani-cli")
             .env("PATH", new_path)
             .env("ANICLI_TARGET", &anime.title)
+            .arg(dub)
             .arg("--no-detach")
             .arg("--exit-after-play")
             .arg("-e")


### PR DESCRIPTION
This change adds a new configuration option dub to the config file, allowing switching between dubbed and subbed versions of anime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration setting to enable dubbed playback.
  * When enabled, playback commands automatically request dubbed audio.
  * Default configurations keep dubbed playback disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->